### PR TITLE
set input size properly

### DIFF
--- a/tagsinput.js
+++ b/tagsinput.js
@@ -461,7 +461,7 @@
         var textLength = $input.val().length,
             wordSpace = Math.ceil(textLength / 5),
             size = textLength + wordSpace + 1;
-        $input.attr('size', Math.max(this.inputSize, $input.val().length));
+        $input.attr('size', Math.max(this.inputSize, size));
       }, self));
 
       self.$container.on('keypress', 'input', $.proxy(function(event) {
@@ -491,7 +491,7 @@
          var textLength = $input.val().length,
             wordSpace = Math.ceil(textLength / 5),
             size = textLength + wordSpace + 1;
-         $input.attr('size', Math.max(this.inputSize, $input.val().length));
+         $input.attr('size', Math.max(this.inputSize, size));
       }, self));
 
       // Remove icon clicked


### PR DESCRIPTION
Size for the internal text input wasn't calculated correctly. You can check this easily by debugging [`$input.val()`](https://github.com/Nodws/bootstrap4-tagsinput/blob/master/tagsinput.js#L464)

It was causing the first char to disappear after typing a few chars (it couldn't fit):

![yknlgkpy2s](https://user-images.githubusercontent.com/399968/27951165-423503b2-6304-11e7-9c30-cb79b2cffcf1.gif)

It's the same for the original [lib](https://github.com/bootstrap-tagsinput/bootstrap-tagsinput), but I'm using tagsinput with bootstrap 4, so I would like to see this fix here :)