### PR TITLE
jQuery selector fix for values containing quotes

### DIFF
--- a/tagsinput.js
+++ b/tagsinput.js
@@ -147,8 +147,8 @@
 
       // Check to see if the tag exists in its raw or uri-encoded form
       var optionExists = (
-        $('option[value="' + encodeURIComponent(itemValue) + '"]', self.$element).length ||
-        $('option[value="' + htmlEncode(itemValue) + '"]', self.$element).length
+        $('option[value="' + encodeURIComponent(itemValue).replace(/"/g, '\\"') + '"]', self.$element).length ||
+        $('option[value="' + htmlEncode(itemValue).replace(/"/g, '\\"') + '"]', self.$element).length
       );
 
       // add <option /> if item represents a value not present in one of the <select />'s options


### PR DESCRIPTION
Input values with double quotes cause a jQuery selector exception. This pull request escapes the input value to achieve a valide selector query.