### PR TITLE
Fix jquery validate error:  "has no name assigned"

### DIFF
--- a/tagsinput.js
+++ b/tagsinput.js
@@ -51,10 +51,12 @@
     this.multiple = (this.isSelect && element.hasAttribute('multiple'));
     this.objectItems = options && options.itemValue;
     this.placeholderText = element.hasAttribute('placeholder') ? this.$element.attr('placeholder') : '';
+    this.name = element.hasAttribute('name') ? this.$element.attr('name') : '';
+    this.type = element.hasAttribute('type') ? this.$element.attr('type') : 'text';
     this.inputSize = Math.max(1, this.placeholderText.length);
 
     this.$container = $('<div class="bootstrap-tagsinput"></div>');
-    this.$input = $('<input type="text" placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
+    this.$input = $('<input type="' + this.type + '" name="' + this.name + '" placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
 
     this.$element.before(this.$container);
 


### PR DESCRIPTION
Problem when using bootstrap tags input on jquery validate plugin.